### PR TITLE
Docker image for tf-seal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM tensorflow/tensorflow:custom-op
+FROM ubuntu:19.04
 
-RUN wget https://github.com/microsoft/SEAL/archive/master.zip
-RUN unzip master.zip
-RUN cd SEAL-master/native/src && cmake . && make && sudo make install
+RUN apt update
+RUN apt install -y wget python3.7 python3-pip
+RUN wget https://storage.googleapis.com/tf-pips/tf-c++17-support/tf_nightly-1.14.0-cp37-cp37m-linux_x86_64.whl && \
+    python3.7 -m pip install tf_nightly-1.14.0-cp37-cp37m-linux_x86_64.whl && \
+    rm tf_nightly-1.14.0-cp37-cp37m-linux_x86_64.whl
+RUN python3.7 -m pip install tf-seal


### PR DESCRIPTION
#33 suggest having a Docker image with a ready workspace with tf-seal's requirements so it's easy for new comers to start testing and using it as well as doing test automation.